### PR TITLE
Quotes

### DIFF
--- a/wpasupplicantconf.py
+++ b/wpasupplicantconf.py
@@ -53,7 +53,7 @@ class WpaSupplicantConf:
                 if network is None:
                     self._fields[left] = right
                 else:
-                    network[left] = right
+                    network[left] = dequote(right)
 
     def fields(self):
         return self._fields
@@ -75,13 +75,22 @@ class WpaSupplicantConf:
             f.write("\nnetwork={\n")
             f.write('    ssid="{}"\n'.format(ssid))
             for name, value in info.items():
+                if isinstance(value, str):
+                    value = '"'+value+'"'
                 f.write("    {}={}\n".format(name, value))
             f.write("}\n")
 
 
 def dequote(v):
-    if len(v) < 2:
-        return v
     if v.startswith('"') and v.endswith('"'):
         return v[1:-1]
-    return v
+    try:
+        # try to cast to int
+        return int(v)
+    except ValueError:
+        try:
+            # try to cast to float
+            return float(v)
+        except ValueError:
+            # well then it's a string...
+            return v

--- a/wpasupplicantconf_test.py
+++ b/wpasupplicantconf_test.py
@@ -88,12 +88,12 @@ def test_networks():
     assert conf.fields() == {}
     assert conf.networks() == OrderedDict([
         ('foo bar', OrderedDict([
-            ("psk", '"secret"'),
+            ("psk", 'secret'),
             ("eap", "TLS"),
         ])),
         ('nsa', OrderedDict([
-            ("psk", '"password"'),
-            ("scan_ssid", "1"),
+            ("psk", 'password'),
+            ("scan_ssid", 1),
         ])),
     ])
 
@@ -142,7 +142,7 @@ def test_full_config():
     ])
     assert conf.networks() == OrderedDict([
         ('foo bar', OrderedDict([
-            ("psk", '"secret"'),
+            ("psk", 'secret'),
             ("eap", "TLS"),
         ])),
     ])
@@ -176,7 +176,7 @@ def test_add_network():
 
     assert conf.networks() == OrderedDict([
         ('foo bar', {
-            "psk": '"secret"'
+            "psk": 'secret'
         }),
         ('another', {
             "psk": "hi"
@@ -201,7 +201,7 @@ def test_remove_network():
     conf.remove_network("bar")
     assert conf.networks() == OrderedDict([
         ('foo', {
-            "psk": '"foopass"'
+            "psk": 'foopass'
         }),
     ])
 
@@ -221,8 +221,8 @@ def test_write():
         """))
     conf = WpaSupplicantConf(inp)
 
-    conf.add_network("foo", psk='"foo pass"', wow='man')
-    conf.add_network("bar", psk='"bar pass"')
+    conf.add_network("foo", psk='foo pass', wow='man')
+    conf.add_network("bar", psk='bar pass')
 
     out = StringIO()
     conf.write(out)
@@ -235,7 +235,7 @@ update_config=1
 network={
     ssid="foo"
     psk="foo pass"
-    wow=man
+    wow="man"
 }
 
 network={

--- a/wpasupplicantconf_test.py
+++ b/wpasupplicantconf_test.py
@@ -243,3 +243,39 @@ network={
     psk="bar pass"
 }
 """
+
+def test_quotes():
+    inp = StringIO(
+        dedent("""\
+        country=NZ
+        ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+        update_config = 1
+        """))
+    conf = WpaSupplicantConf(inp)
+
+    conf.add_network("foo", string='string', float=1.2, int=3)
+
+    out = StringIO()
+    conf.write(out)
+
+    assert out.getvalue() == """\
+country=NZ
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+
+network={
+    ssid="foo"
+    string="string"
+    float=1.2
+    int=3
+}
+"""
+
+    conf_read = WpaSupplicantConf(out.getvalue().splitlines())
+    assert conf_read.networks() == OrderedDict([
+        ('foo', {
+            "string": 'string',
+            "float": 1.2,
+            "int": 3
+        }),
+    ])


### PR DESCRIPTION
Hi,

Thanks for this utility. Got confused as quotes aren't managed, which isn't very intuitive...

This PR automatically quotes/unquotes strings, and casts back to float/int when possible.

```python
conf.add_network("foo", psk='"pass"')
```
is now
```
conf.add_network("foo", psk='pass')
``` 

and conversely, `conf.networks()['foo']['psk']` now returns `pass` instead of `"pass"`

Warning as this is not backwards compatible though !